### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        run: npm run deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
+  "homepage": "https://nirzaf.github.io/flappy-bird",
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Add configuration for GitHub Pages deployment.

* **package.json**
  - Add `homepage` field with the value `"https://nirzaf.github.io/flappy-bird"`
  - Add `predeploy` script with the value `"npm run build"`
  - Add `deploy` script with the value `"gh-pages -d dist"`

* **.github/workflows/deploy.yml**
  - Create a GitHub Actions workflow file to build and deploy the project to GitHub Pages
  - Use `actions/checkout@v2` to check out the repository
  - Use `actions/setup-node@v2` to set up Node.js
  - Install dependencies using `npm install`
  - Build the project using `npm run build`
  - Deploy to GitHub Pages using `npm run deploy`

